### PR TITLE
feat(api): implementa consumidor Kafka inicial em Go

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,22 @@ services:
         depends_on:
           - kafka
           - coletor-python
+
+  api-go:
+    build: ./services/api-go
+    container_name: api-go
+    ports:
+      - "8081:8081"
+    networks:
+      - netfeeling-network
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_ANALYSIS_TOPIC=analises_concluidas
+    depends_on:
+      mongodb:
+        condition: service_started # Exemplo, podemos ajustar depois
+      kafka:
+        condition: service_healthy
   
   kafka-topic-creator:
     image: confluentinc/cp-kafka:7.0.1

--- a/services/api-go/Dockerfile
+++ b/services/api-go/Dockerfile
@@ -1,0 +1,33 @@
+# --- Estágio 1: Build ---
+FROM golang:1.24-bookworm AS builder
+
+# Instala as dependências de build. 'apt-get' é o gerenciador de pacotes do Debian.
+RUN apt-get update && apt-get install -y build-essential librdkafka-dev
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod tidy
+
+COPY . .
+
+# Compila o nosso código.
+RUN go build -o /app/server .
+
+
+# --- Estágio 2: Runtime ---
+# Usamos uma base 'slim' do Debian para o ambiente final. É leve e compatível.
+FROM debian:bookworm-slim
+
+# Instala apenas a biblioteca C 'librdkafka' necessária para a execução.
+RUN apt-get update && apt-get install -y librdkafka1 && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root/
+
+# Copia o binário compilado do estágio de build.
+COPY --from=builder /app/server .
+
+EXPOSE 8081
+
+# Executa o nosso servidor.
+CMD ["./server"]

--- a/services/api-go/go.mod
+++ b/services/api-go/go.mod
@@ -1,0 +1,5 @@
+module netfeeling/api-go
+
+go 1.24.5
+
+require github.com/confluentinc/confluent-kafka-go/v2 v2.11.0 // indirect

--- a/services/api-go/go.sum
+++ b/services/api-go/go.sum
@@ -1,0 +1,2 @@
+github.com/confluentinc/confluent-kafka-go/v2 v2.11.0 h1:rsqfCqZXAHjWQp4TuRgiNPuW1BlF3xO/5+TsE9iHApw=
+github.com/confluentinc/confluent-kafka-go/v2 v2.11.0/go.mod h1:hScqtFIGUI1wqHIgM3mjoqEou4VweGGGX7dMpcUKves=

--- a/services/api-go/main.go
+++ b/services/api-go/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+// A função que lida com requisições HTTP permanece a mesma por enquanto.
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Println("Endpoint raiz da API Go foi acessado.")
+	fmt.Fprintf(w, "API Dashboard em Go está de pé e consumindo do Kafka!")
+}
+
+// Função para iniciar o consumidor Kafka em uma goroutine.
+func iniciarConsumidor() {
+	// Lê as configurações do Kafka a partir de variáveis de ambiente.
+	kafkaServer := os.Getenv("KAFKA_BOOTSTRAP_SERVERS")
+	topic := os.Getenv("KAFKA_ANALYSIS_TOPIC")
+	groupID := "api-go-group"
+
+	// Configura e cria o consumidor.
+	consumer, err := kafka.NewConsumer(&kafka.ConfigMap{
+		"bootstrap.servers": kafkaServer,
+		"group.id":          groupID,
+		"auto.offset.reset": "earliest",
+	})
+
+	if err != nil {
+		log.Fatalf("Falha ao criar o consumidor Kafka: %s", err)
+	}
+
+	// Inscreve o consumidor no tópico desejado.
+	consumer.SubscribeTopics([]string{topic}, nil)
+	log.Printf("Consumidor Kafka inscrito no tópico '%s'", topic)
+
+	// Canal para receber sinais do sistema operacional para um desligamento gracioso.
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+
+	run := true
+	for run {
+		select {
+		case <-sigchan:
+			log.Println("Recebido sinal de interrupção, desligando consumidor...")
+			run = false
+		default:
+			// Espera por uma mensagem por até 100ms.
+			ev := consumer.Poll(100)
+			if ev == nil {
+				continue
+			}
+
+			switch e := ev.(type) {
+			case *kafka.Message:
+				// Mensagem recebida! Por enquanto, apenas imprimimos no console.
+				log.Printf("==> Mensagem recebida do Kafka:\n%s\n", string(e.Value))
+			case kafka.Error:
+				// Erros do Kafka (ex: desconexão)
+				log.Printf("%% Erro no Kafka: %v\n", e)
+				run = false
+			}
+		}
+	}
+
+	log.Println("Fechando o consumidor Kafka...")
+	consumer.Close()
+}
+
+
+func main() {
+	// Inicia o consumidor Kafka para rodar em paralelo (em uma goroutine).
+	// O 'go' na frente da chamada da função faz isso acontecer.
+	go iniciarConsumidor()
+
+	// O servidor web continua rodando na goroutine principal.
+	http.HandleFunc("/", handler)
+	log.Println("Servidor Go iniciado na porta 8081...")
+	err := http.ListenAndServe(":8081", nil)
+	if err != nil {
+		log.Fatal("Erro ao iniciar o servidor: ", err)
+	}
+}


### PR DESCRIPTION
O serviço api-go agora consome mensagens do tópico 'analises_concluidas' e as exibe no log. A base do Docker foi alterada para Debian/bookworm para resolver incompatibilidades com a librdkafka.